### PR TITLE
Add: 항목삭제기능 구현완료

### DIFF
--- a/src/Pages/ProductNotice/ProductNotice.js
+++ b/src/Pages/ProductNotice/ProductNotice.js
@@ -46,6 +46,13 @@ export default function ProductNotice() {
     nextId.current += 1;
   };
 
+  const RemoveList = id => {
+    return contentsData.length !== 1
+      ? setContentsData(contentsData.filter(el => el.id !== id))
+      : null;
+  };
+
+  console.log(contentsData);
   const [infoValueList, setInfoValueList] = useState('');
   const inputTitle = [
     {
@@ -84,9 +91,6 @@ export default function ProductNotice() {
     const { name, value } = e.target;
     setInfoValueList({ ...infoValueList, [name]: value });
   };
-
-  console.log(infoValueList);
-  console.log(contentsData);
 
   return (
     <ContentsBox>
@@ -129,7 +133,9 @@ export default function ProductNotice() {
                       onChange={getInputNew}
                       name={el.tagContents}
                     />
-                    <DeleteButton />
+                    <S.DeleteButton onClick={() => RemoveList(el.id)}>
+                      삭제
+                    </S.DeleteButton>
                   </S.NewInputWrap>
                 </S.InputDataWrap>
               );

--- a/src/Pages/ProductNotice/ProductNotice_Style.js
+++ b/src/Pages/ProductNotice/ProductNotice_Style.js
@@ -44,3 +44,12 @@ export const NewInputWrap = styled.div`
   display: flex;
   justify-content: space-between;
 `;
+
+export const DeleteButton = styled.div`
+  padding: 5px;
+  width: 60px;
+  text-align: center;
+  color: red;
+  border: 1px solid;
+  border-radius: 5px;
+`;


### PR DESCRIPTION
## :: 최근 작업 주제

- [x]  기능 추가
- [ ]  리뷰 반영
- [ ]  리팩토링
- [ ]  버그 수정
- [ ]  컨벤션 수정

<br />

## :: 구현 목표
- 추가된 항목 버튼 삭제 기능
- 한 개는 디폴트로 고정

<br />

## :: 구현 사항 설명 

1. 항목 삭제 기능
- remove 함수를 생성하여 UI를 그려주는 배열의 요소 개별 아이디를 인자로 받아 필터함수를 이용하여 같지 않은 아이디값만 새롭게 반환해주는 함수 구현
2. 항목 한 개 이상에서만 필터함수 작동
- 조건부로 배열의 갯수가 1개 일때는 삭제함수 발동 안함.

<br />

## :: 성장 포인트 

- 필터함수를 이용하여 삭제를 해주는 법을 배웠습니다. 
- 삭제 시 아이디를 필수적으로 인자로 담아 보내줘야한다는 것을 배웠습니다.
- onClick={someFunction()} 을 해버리면 해당 콤포넌트가 렌더링이 되는것과 동시에 someFunction함수를 실행시켜버린다.
그래서 보통 onClick={someFunction} 으로 지정해서 () 를 제외하는 방법으로 함수가 즉시실행 되지 않게 하고, 클릭했을때 실행이 되게 해준다.
onRemove의 경우, 해당 함수가 실행될 떄 아이디 값도 받아와야 하는 경우에는 onClick = { onRemove(somting.id) } 를 해버리면, 해당 콤포넌트가 렌더링됨가 동시에 이 함수 실행이 되어버려서 렌더링이 ㅌ되지 않고 오류가 발생한다.

따라서 이런 문제들을 해결하기 위해 onClick에 콜백 함수를 넣어주고, 해당 함수가 실행될 때 someting.id를 건네주어 실행시키는 방법으로 처리를 해준다는 것을 배웠다. 인자를 건내줘야할 때에는 onClick={()=>{}} 으로 사용하여야한다.

<br />

## :: 특이 사항
없습니다.

